### PR TITLE
Only update Dtr when needed

### DIFF
--- a/Eventy/Plugin.cs
+++ b/Eventy/Plugin.cs
@@ -28,7 +28,7 @@ public class Plugin : IDalamudPlugin
     public MainWindow MainWindow { get; init; }
 
     private readonly PluginCommandManager<Plugin> CommandManager;
-    private readonly ServerBar ServerBar;
+    public readonly ServerBar ServerBar;
 
     public FrozenDictionary<long, ParsedEvent[]> Events = FrozenDictionary<long, ParsedEvent[]>.Empty;
 
@@ -37,7 +37,7 @@ public class Plugin : IDalamudPlugin
         Configuration = PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
 
         MainWindow = new MainWindow(this);
-        ConfigWindow = new ConfigWindow();
+        ConfigWindow = new ConfigWindow(this);
 
         WindowSystem.AddWindow(MainWindow);
         WindowSystem.AddWindow(ConfigWindow);

--- a/Eventy/ServerBar.cs
+++ b/Eventy/ServerBar.cs
@@ -38,6 +38,11 @@ public class ServerBar
         DtrEntry.Remove();
     }
 
+    public void Refresh()
+    {
+        LastRefresh = 0;
+    }
+
     public void UpdateDtrBar(IFramework framework)
     {
         if (!Plugin.Configuration.ShowDtrEntry)
@@ -47,7 +52,7 @@ public class ServerBar
         }
 
         // Only refresh every 5s
-        if (Environment.TickCount64 + 5000 < LastRefresh)
+        if (Environment.TickCount64 - 5000 < LastRefresh)
             return;
         LastRefresh = Environment.TickCount64;
 
@@ -79,7 +84,11 @@ public class ServerBar
         DtrEntry!.Text = text;
     }
 
-    private void UpdateVisibility(bool shown) => DtrEntry!.Shown = shown;
+    private void UpdateVisibility(bool shown)
+    {
+        if (DtrEntry!.Shown != shown)
+            DtrEntry!.Shown = shown;
+    }
 
     private void OnClick()
     {

--- a/Eventy/Windows/Config/ConfigWindow.Settings.cs
+++ b/Eventy/Windows/Config/ConfigWindow.Settings.cs
@@ -12,7 +12,10 @@ public partial class ConfigWindow
             changed |= ImGui.Checkbox("Use Short Version", ref Plugin.Configuration.UseShortVersion);
 
             if (changed)
+            {
                 Plugin.Configuration.Save();
+                Plugin.ServerBar.Refresh();
+            }
 
             ImGui.EndTabItem();
         }

--- a/Eventy/Windows/Config/ConfigWindow.cs
+++ b/Eventy/Windows/Config/ConfigWindow.cs
@@ -4,8 +4,12 @@ namespace Eventy.Windows.Config;
 
 public partial class ConfigWindow : Window, IDisposable
 {
-    public ConfigWindow() : base("Configuration##Eventy")
+    private readonly Plugin Plugin;
+
+    public ConfigWindow(Plugin plugin) : base("Configuration##Eventy")
     {
+        Plugin = plugin;
+
         this.SizeConstraints = new WindowSizeConstraints
         {
             MinimumSize = new Vector2(300, 200),


### PR DESCRIPTION
The main change here is just changing `Environment.TickCount64 + 5000` to `Environment.TickCount64 - 5000` so that the 5 second throttle actually works.

However when we do that it makes toggling the "Use Short Version" option (for example) quite unresponsive, and fixing that meant changing some things to public and was a little messier. Don't know if this part is really needed or not.

I also modified `UpdateVisibility` to check the state of the shown flag before toggling it, because setting it blindly every frame means the internal `isDirty` flag for that DtrBarEntry is set, which in turn causes Dalamud to do a bit of unnecessary processing to update it each frame even when it doesn't change.