### PR TITLE
Use invisible button for click detection

### DIFF
--- a/Eventy/Windows/Main/MainWindow.cs
+++ b/Eventy/Windows/Main/MainWindow.cs
@@ -219,15 +219,16 @@ public class MainWindow : Window, IDisposable
                 var lineMax = max with { Y = min.Y + spacing + (5.0f * ImGuiHelpers.GlobalScale) };
 
                 drawList.AddRectFilled(lineMin, lineMax, currentMonth ? ev.Color : ev.Opacity);
-                if (ImGui.IsMouseHoveringRect(lineMin, lineMax))
-                {
-                    ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
 
+                ImGui.SetCursorScreenPos(lineMin);
+                if (ImGui.InvisibleButton($"##event{ev.Id}", lineMax - lineMin) && ev.Url != "")
+                    Utils.OpenUrl(ev.Url.Replace("//eu", $"//{Plugin.Configuration.Subdomain.ToValue()}"));
+
+                if (ImGui.IsItemHovered())
+                {
                     using var textColor = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudGrey);
                     ImGui.SetTooltip($"{ev.Name}\n{ev.Begin:f} - {ev.End:f}");
-
-                    if (ev.Url != "" && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
-                        Utils.OpenUrl(ev.Url.Replace("//eu", $"//{Plugin.Configuration.Subdomain.ToValue()}"));
+                    ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
                 }
             }
         }


### PR DESCRIPTION
Replaces manual Rect/Click check on events with an invisible button. The main benefit of this is that it prevents the click event hitting the underlying window (it's consumed by the button). Without this, opening an event in the browser can additionally cause the Eventy window to start dragging when tabbing back into the game.